### PR TITLE
Add support for `allOf`, `x-nullable`, `x-abstract`, `example`, `discriminator`, and more…

### DIFF
--- a/Sources/AllOfSchema.swift
+++ b/Sources/AllOfSchema.swift
@@ -1,0 +1,48 @@
+import ObjectMapper
+
+public struct AllOfSchema {
+    public let metadata: Metadata
+    
+    public let schemas: [Schema]
+    
+    /// Determines whether or not the schema should be considered abstract code 
+    /// generation purposes. This can be used to indicate that a schema is an 
+    /// interface rather than a concrete model object.
+    ///
+    /// Corresponds to the boolean value for `x-abstract`. The default value is 
+    /// false.
+    public let abstract: Bool
+}
+
+public struct AllOfSchemaBuilder {
+    
+    typealias Building = AllOfSchema
+    
+    let metadata: MetadataBuilder
+    let schemaBuilders: [SchemaBuilder]
+    
+    /// See AllOfSchema.abstract
+    let abstract: Bool
+    
+    init(map: Map) throws {
+        metadata = try MetadataBuilder(map: map)
+        
+        let allOf: [[String:Any]] = try map.value("allOf")
+        schemaBuilders = allOf
+            .map {Map(mappingType: .fromJSON, JSON: $0)}
+            .flatMap { map -> SchemaBuilder? in
+                guard let schemaBuilder = try? SchemaBuilder(map: map) else {
+                    return nil
+                }
+                return schemaBuilder
+            }
+        abstract = (try? map.value("x-abstract")) ?? false
+    }
+    
+    func build(_ swagger: SwaggerBuilder) throws -> AllOfSchema {
+        let schemas = try schemaBuilders.map {try $0.build(swagger)}
+        return AllOfSchema(metadata: try self.metadata.build(swagger), schemas: schemas,
+                           abstract: self.abstract)
+    }
+    
+}

--- a/Sources/Dictionary+Extensions.swift
+++ b/Sources/Dictionary+Extensions.swift
@@ -1,4 +1,3 @@
-
 extension Dictionary {
     init(_ array: [(Key, Value)]) {
         var dictionary = Dictionary<Key, Value>(minimumCapacity: array.count)

--- a/Sources/Enums.swift
+++ b/Sources/Enums.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-public enum StringFormat: String {
+public enum StringFormat: RawRepresentable {
+
+    public typealias RawValue = String
 
     /// Base64 encoded characters
     case byte
@@ -12,10 +14,41 @@ public enum StringFormat: String {
     case date
 
     /// As defined by date-time - RFC3339
-    case dateTime = "date-time"
+    case dateTime
 
     /// Used to hint UIs the input needs to be obscured.
     case password
+    
+    /// A custom format
+    case other(String)
+    
+    public init(rawValue: RawValue) {
+        switch rawValue {
+        case StringFormat.Byte: self = .byte
+        case StringFormat.Binary: self = .binary
+        case StringFormat.Date: self = .date
+        case StringFormat.DateTime: self = .dateTime
+        case StringFormat.Password: self = .password
+        default: self = .other(rawValue)
+        }
+    }
+    
+    public var rawValue: RawValue {
+        switch self {
+        case .byte: return StringFormat.Byte
+        case .binary: return StringFormat.Binary
+        case .date: return StringFormat.Date
+        case .dateTime: return StringFormat.DateTime
+        case .password: return StringFormat.Password
+        case .other(let other): return other
+        }
+    }
+    
+    private static let Byte = "byte"
+    private static let Binary = "binary"
+    private static let Date = "date"
+    private static let DateTime = "date-time"
+    private static let Password = "password"
 }
 
 public enum IntegerFormat: String {
@@ -40,6 +73,8 @@ public enum DataType: String {
     case integer = "integer"
     case enumeration = "enumeration"
     case boolean = "boolean"
+    case reference = "reference"
+    case allOf = "allOf"
 }
 
 public enum SimpleDataType: String {

--- a/Sources/FixedParameterFields.swift
+++ b/Sources/FixedParameterFields.swift
@@ -23,6 +23,9 @@ public struct FixedParameterFields {
     /// Determines whether this parameter is mandatory. If the parameter is in "path", this property is
     /// required and its value MUST be true. Its default value is false.
     public let required: Bool
+    
+    /// An example value for the parameter.
+    public let example: Any?
 }
 
 struct FixedParameterFieldsBuilder: Builder {
@@ -32,16 +35,18 @@ struct FixedParameterFieldsBuilder: Builder {
     let location: ParameterLocation
     let description: String?
     let required: Bool
+    let example: Any?
 
     init(map: Map) throws {
         name = try map.value("name")
         location = try map.value("in")
         description = try? map.value("description")
         required = (try? map.value("required")) ?? false
+        example = try? map.value("x-example")
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> FixedParameterFields {
         return FixedParameterFields(name: self.name, location: self.location, description: self.description,
-                                    required: self.required)
+                                    required: self.required, example: self.example)
     }
 }

--- a/Sources/Items.swift
+++ b/Sources/Items.swift
@@ -36,7 +36,7 @@ indirect enum ItemsBuilder: Builder {
             self = .array(builder: try ArrayItemBuilder(map: map))
         case .boolean:
             self = .boolean(builder: metadata)
-        case .enumeration, .object:
+        case .enumeration, .object, .reference, .allOf:
             throw DecodingError()
         }
     }

--- a/Sources/Metadata.swift
+++ b/Sources/Metadata.swift
@@ -16,6 +16,12 @@ public struct Metadata {
 
     /// Used to restrict the schema to a specific set of values.
     public let enumeratedValues: [Any?]?
+    
+    /// An example value for the schema.
+    public let example: Any?
+    
+    /// Whether or not the schema can be nil. Corresponds to `x-nullable`.
+    public let nullable: Bool
 }
 
 struct MetadataBuilder: Builder {
@@ -26,9 +32,13 @@ struct MetadataBuilder: Builder {
     let description: String?
     let defaultValue: Any?
     let enumeratedValues: [Any?]?
+    let example: Any?
+    let nullable: Bool
 
     init(map: Map) throws {
-        if let typeString: String = try? map.value("type"), let mappedType = DataType(rawValue: typeString) {
+        if map.JSON["$ref"] != nil {
+            type = .reference
+        } else if let typeString: String = try? map.value("type"), let mappedType = DataType(rawValue: typeString) {
             type = mappedType
         } else if map.JSON["items"] != nil {
             // Implicit array
@@ -38,6 +48,8 @@ struct MetadataBuilder: Builder {
             type = .object
         } else if map.JSON["enum"] != nil {
             type = .enumeration
+        } else if map.JSON["allOf"] != nil {
+            type = .allOf
         } else {
             throw DecodingError()
         }
@@ -46,10 +58,17 @@ struct MetadataBuilder: Builder {
         description = try? map.value("description")
         defaultValue = try? map.value("default")
         enumeratedValues = try? map.value("enum")
+        example = try? map.value("example")
+        nullable = (try? map.value("x-nullable")) ?? false
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> Metadata {
+        return self.build()
+    }
+    
+    func build() -> Metadata {
         return Metadata(type: self.type, title: self.title, description: self.description,
-                        defaultValue: self.defaultValue, enumeratedValues: self.enumeratedValues)
+                        defaultValue: self.defaultValue, enumeratedValues: self.enumeratedValues,
+                        example: self.example, nullable: self.nullable)
     }
 }

--- a/Sources/ObjectSchema.swift
+++ b/Sources/ObjectSchema.swift
@@ -7,6 +7,15 @@ public struct ObjectSchema {
     public let minProperties: Int?
     public let maxProperties: Int?
     public let additionalProperties: Either<Bool, Schema>
+    public let discriminator: String?
+    
+    /// Determines whether or not the schema should be considered abstract code
+    /// generation purposes. This can be used to indicate that a schema is an
+    /// interface rather than a concrete model object.
+    ///
+    /// Corresponds to the boolean value for `x-abstract`. The default value is
+    /// false.
+    public let abstract: Bool
 }
 
 struct ObjectSchemaBuilder: Builder {
@@ -19,6 +28,10 @@ struct ObjectSchemaBuilder: Builder {
     let minProperties: Int?
     let maxProperties: Int?
     let additionalProperties: Either<Bool, SchemaBuilder>
+    let discriminator: String?
+    
+    /// See ObjectSchema.abstract
+    let abstract: Bool
 
     init(map: Map) throws {
         metadata = try MetadataBuilder(map: map)
@@ -27,6 +40,8 @@ struct ObjectSchemaBuilder: Builder {
         minProperties = try? map.value("minProperties")
         maxProperties = try? map.value("maxProperties")
         additionalProperties = (try? Either(map: map, key: "additionalProperties")) ?? .a(false)
+        discriminator = try? map.value("discriminator")
+        abstract = (try? map.value("x-abstract")) ?? false
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> ObjectSchema {
@@ -44,6 +59,7 @@ struct ObjectSchemaBuilder: Builder {
 
         return ObjectSchema(metadata: try self.metadata.build(swagger), required: self.required,
                             properties: properties, minProperties: self.minProperties,
-                            maxProperties: self.maxProperties, additionalProperties: additionalProperties)
+                            maxProperties: self.maxProperties, additionalProperties: additionalProperties,
+                            discriminator: self.discriminator, abstract: self.abstract)
     }
 }

--- a/Sources/ResolveReference.swift
+++ b/Sources/ResolveReference.swift
@@ -1,0 +1,306 @@
+import Foundation
+import ObjectMapper
+
+public enum ReferenceResolvingError: Error {
+    case baseURL(URL)
+    case definitions([String: Any])
+    case definitionNameMismatch(existing: String, reference: String?)
+    case paths([String: Any])
+    case path([String: Any])
+    case responses([String: Any])
+    case properties([String: Any])
+    case reference(String)
+    case referenceContent(String)
+    case referenceFragment(String)
+    case referenceName(String?)
+    case definitionNotFoundForFile(name: String, baseURL: URL)
+}
+
+extension Dictionary where Key == String {
+    private typealias Definition = [String: Any]
+    private typealias Definitions = [String: Definition]
+    
+    /// Returns a [String: Any] where all external model object definition 
+    /// references found in 
+    /// self["paths"][<path>][<method>]["responses"][<code>]["schema"]
+    /// are read from disk and set at self["definitions"][<file_name>], and
+    /// the "$ref" for those external references is updated to point to the 
+    /// local definition found in self["definitions"].
+    ///
+    /// If a json file is found in the containing directory (or if it's 
+    /// subdirectories) that is not referenced by the file found at 
+    /// `baseSpecURL` then there must exist a reference to the unreferenced file 
+    /// in self["definitions"] with a name that matches the filename without the 
+    /// file extension.
+    func resolvingReferences(withBaseSpecURL baseSpecURL: URL) throws -> [String: Any] {
+        let baseURL = baseSpecURL.deletingLastPathComponent()
+        
+        var isDirectory: ObjCBool = false
+        FileManager.default.fileExists(atPath: baseURL.path, isDirectory: &isDirectory)
+        guard isDirectory.boolValue else {
+            throw ReferenceResolvingError.baseURL(baseURL)
+        }
+        
+        var newSelf = self as [String: Any]
+        
+        var definitions: Definitions
+        if let existingDefinitions = self["definitions"] as? Definitions {
+            definitions = try existingDefinitions.resolvingReferencesInDefinitions(withBaseURL: baseURL)
+        } else {
+            definitions = Definitions()
+        }
+        
+        if let paths = self["paths"] as? [String: Any] {
+            newSelf["paths"] = try paths.resolvingReferencesInPaths(withBaseURL: baseURL, definitions: &definitions)
+        }
+        
+        newSelf["definitions"] = definitions
+        
+        let baseSpecFilename = (baseSpecURL.lastPathComponent as NSString).deletingPathExtension
+        let expectedFileNames = Array(definitions.keys) + [baseSpecFilename]
+        do {
+            try baseURL.validatePresenceOfFiles(withFileNames: expectedFileNames, pathExtension: "json")
+        } catch FilePresenceValidationError.invalidURL {
+            throw ReferenceResolvingError.baseURL(baseURL)
+        } catch FilePresenceValidationError.nameNotFoundForFile(let name) {
+            throw ReferenceResolvingError.definitionNotFoundForFile(name: name, baseURL: baseURL)
+        }
+        
+        return newSelf
+    }
+    
+    private func resolvingReferencesInDefinitions(withBaseURL baseURL: URL) throws -> Definitions {
+        guard let definitions = self as? Definitions else {
+            throw ReferenceResolvingError.definitions(self)
+        }
+        
+        var newDefinitions = Definitions()
+        var resolvedDefinitions = Definitions()
+        
+        try definitions.forEach { (name, definition) in
+            let resolvedDefinition = try definition.resolvingReferencesInSchema(withBaseURL: baseURL, definitions: &resolvedDefinitions)
+            
+            // Do not include resolved objects.
+            if let referencePath = resolvedDefinition["$ref"] as? String {
+                let referencePathComponents = referencePath.components(separatedBy: "/")
+                guard
+                    let refName = referencePathComponents.last,
+                    refName == name else {
+                        throw ReferenceResolvingError.definitionNameMismatch(existing: name, reference: referencePathComponents.last)
+                }
+                return
+            }
+            
+            newDefinitions[name] = resolvedDefinition
+        }
+        
+        newDefinitions += resolvedDefinitions
+        
+        return newDefinitions
+    }
+    
+    private typealias Operation = [String: Any]
+    private typealias Path = [String: Operation]
+    private typealias Paths = [String: Path]
+    
+    private func resolvingReferencesInPaths(withBaseURL baseURL: URL, definitions: inout Definitions) throws -> Paths {
+        guard let paths = self as? Paths else {
+            throw ReferenceResolvingError.paths(self)
+        }
+        
+        var newPaths = paths
+        try paths.forEach { (pathName, path) in
+            newPaths[pathName] = try path.resolvingReferencesInPath(withBaseURL: baseURL, definitions: &definitions)
+        }
+        return newPaths
+    }
+    
+    private func resolvingReferencesInPath(withBaseURL baseURL: URL, definitions: inout Definitions) throws -> Path {
+        guard let path = self as? Path else {
+            throw ReferenceResolvingError.path(self)
+        }
+        
+        var newPath = path
+        try path.forEach { (operationType, operation) in
+            newPath[operationType] = try operation.resolvingReferencesInOperation(withBaseURL: baseURL, definitions: &definitions)
+        }
+        return newPath
+    }
+    
+    private typealias Response = [String: Any]
+    private typealias Responses = [String: Response]
+    
+    private func resolvingReferencesInOperation(withBaseURL baseURL: URL, definitions: inout Definitions) throws -> Operation {
+        var newOperation = self as Operation
+        if let responses = self["responses"] as? Responses {
+            newOperation["responses"] = try responses.resolvingReferencesInResponses(withBaseURL: baseURL, definitions: &definitions)
+        }
+        return newOperation
+    }
+    
+    private func resolvingReferencesInResponses(withBaseURL baseURL: URL, definitions: inout Definitions) throws -> Responses {
+        guard let responses = self as? Responses else {
+            throw ReferenceResolvingError.responses(self)
+        }
+        
+        var newResponses = responses
+        try responses.forEach { (code, response) in
+            newResponses[code] = try response.resolvingReferencesInResponse(withBaseURL: baseURL, definitions: &definitions)
+        }
+        return newResponses
+    }
+    
+    private typealias Schema = [String: Any]
+    
+    private func resolvingReferencesInResponse(withBaseURL baseURL: URL, definitions: inout Definitions) throws -> Response {
+        var newResponse = self as Response
+        if let schema = self["schema"] as? Schema {
+            newResponse["schema"] = try schema.resolvingReferencesInSchema(withBaseURL: baseURL, definitions: &definitions)
+        }
+        return newResponse
+    }
+    
+    private typealias AllOfSchema = [Schema]
+    private typealias Property = [String: Any]
+    private typealias Properties = [String: Property]
+    
+    private func resolvingReferencesInSchema(withBaseURL baseURL: URL, definitions: inout Definitions) throws -> Schema {
+        var newSelf = self as Schema
+        if let properties = newSelf["properties"] as? Properties {
+            newSelf["properties"] = try properties.resolvingReferencesInProperties(withBaseURL: baseURL, definitions: &definitions)
+        }
+        
+        if let items = newSelf["items"] as? Schema {
+            newSelf["items"] = try items.resolvingReferencesInSchema(withBaseURL: baseURL, definitions: &definitions)
+        }
+        
+        guard let ref = self["$ref"] as? String else {
+            return newSelf
+        }
+        
+        // If url has no content (fragment only) then this is a local reference
+        // (e.g. "#/definitions/Foo") and no changes are necessary.
+        guard
+            let refURL = URL(string: ref),
+            refURL.lastPathComponent.characters.count > 0 else {
+                return newSelf
+        }
+        
+        guard let absoluteRefURL = URL(string: ref, relativeTo: baseURL) else {
+            throw ReferenceResolvingError.reference(ref)
+        }
+        
+        let jsonString = try NSString(contentsOfFile: absoluteRefURL.path, encoding: String.Encoding.utf8.rawValue) as String
+        guard let unresolvedRefJSON = Mapper<SwaggerBuilder>.parseJSONStringIntoDictionary(JSONString: jsonString) else {
+            throw ReferenceResolvingError.referenceContent(jsonString)
+        }
+        
+        let refBaseURL = absoluteRefURL.deletingLastPathComponent()
+        var refJSON = try unresolvedRefJSON.resolvingReferencesInSchema(withBaseURL: refBaseURL, definitions: &definitions)
+        
+        let name: String
+        if let fragment = refURL.fragment {
+            let fragments = fragment.components(separatedBy: "/")
+            
+            // TODO: Support nested json object pointers in references.
+            guard fragments.count == 1 else {
+                throw ReferenceResolvingError.referenceFragment(fragment)
+            }
+            
+            guard let last = fragments.last, last.characters.count > 0 else {
+                throw ReferenceResolvingError.referenceName(fragments.last)
+            }
+            name = last
+        } else {
+            name = refURL.deletingPathExtension().lastPathComponent
+        }
+        
+        newSelf["$ref"] = "#/definitions/\(name)"
+        
+        if let refJSONAllOf = refJSON["allOf"] as? AllOfSchema {
+            var newRefJSONAllOf = refJSONAllOf
+            try refJSONAllOf.enumerated().forEach { (index, allOfSchema) in
+                newRefJSONAllOf[index] = try allOfSchema.resolvingReferencesInSchema(withBaseURL: refBaseURL, definitions: &definitions)
+            }
+            refJSON["allOf"] = newRefJSONAllOf
+        }
+        
+        definitions[name] = refJSON
+        
+        return newSelf
+    }
+    
+    private func resolvingReferencesInProperties(withBaseURL baseURL: URL, definitions: inout Definitions) throws -> Properties {
+        guard let properties = self as? Properties else {
+            throw ReferenceResolvingError.properties(self)
+        }
+        
+        var newProperties = properties
+        try properties.forEach { (propertyName, property) in
+            newProperties[propertyName] = try property.resolvingReferencesInSchema(withBaseURL: baseURL, definitions: &definitions)
+        }
+        return newProperties
+    }
+}
+
+enum FilePresenceValidationError: Error {
+    case invalidURL
+    case nameNotFoundForFile(name: String)
+}
+
+extension URL {
+    /// Enumerates all files with the provided extension in the reciever's 
+    /// directory and asserts that a string exists in `names` that matches the 
+    /// file's name. This function can throw `FilePresenceValidationError`s.
+    func validatePresenceOfFiles(withFileNames names: [String], pathExtension: String) throws {
+        guard let enumerator = FileManager.default.enumerator(atPath: self.path) else {
+            throw FilePresenceValidationError.invalidURL
+        }
+        
+        while let filename = enumerator.nextObject() as? NSString {
+            guard filename.pathExtension == pathExtension else {
+                continue
+            }
+            
+            let name = (filename.lastPathComponent as NSString).deletingPathExtension
+            if !names.contains(name) {
+                throw FilePresenceValidationError.nameNotFoundForFile(name: name)
+            }
+        }
+    }
+}
+
+fileprivate func += <Key, Value> (left: inout [Key: Value], right: [Key: Value]) {
+    right.forEach {left[$0.key] = $0.value}
+}
+
+extension ReferenceResolvingError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .baseURL(let url):
+            return "Invalid base URL: \(url)."
+        case .definitions(let definitions):
+            return "Invalid definitions: \(definitions)."
+        case .definitionNameMismatch(let existing, let reference):
+            return "Definition name '\(existing)' does not match reference file name '\(reference ?? "<invalid>")'."
+        case .paths(let paths):
+            return "Invalid paths: \(paths)."
+        case .path(let path):
+            return "Invalid path: \(path)."
+        case .responses(let responses):
+            return "Invalid responses: \(responses)"
+        case .properties(let properties):
+            return "Invalid properties: \(properties)"
+        case .reference(let reference):
+            return "Invalid reference: \(reference)"
+        case .referenceContent(let jsonString):
+            return "Invalid reference content: \(jsonString)"
+        case .referenceFragment(let fragment):
+            return "Invalid reference fragment: \(fragment)"
+        case .referenceName(let name):
+            return "Invalid reference name: \(name ?? "<nil>")"
+        case .definitionNotFoundForFile(let name, let baseURL):
+            return "Definition not found for file named \(name) at \(baseURL)."
+        }
+    }
+}

--- a/Sources/SchemaStructure.swift
+++ b/Sources/SchemaStructure.swift
@@ -1,0 +1,5 @@
+public struct SchemaStructure {
+    public let name: String
+    public let schema: Schema
+    public let metadata: Metadata
+}

--- a/Sources/Swagger.swift
+++ b/Sources/Swagger.swift
@@ -61,6 +61,30 @@ extension Swagger {
         let builder = try SwaggerBuilder(JSONString: string)
         self = try builder.build(builder)
     }
+    
+    /// Initializes a Swagger struct using the Swagger spec at the provided URL
+    /// and resolves any external references to model objects found in response 
+    /// object schemas and adds them to `definitions`. This only includes
+    /// references found at `paths.<path>.<method>.responses.schema.$ref.
+    ///
+    /// If `.json` files exist in the directory that the spec file is contained 
+    /// (or any of its subfolders recusively) that are not referenced by the
+    /// base spec file or any of the model files that the base spec references,
+    /// ReferenceResolvingError.definitionNotFoundForFile will be thrown.
+    ///
+    /// This initializer can throw any errors that could be thrown by the other
+    /// intiailizers as well as `ReferenceResolvingError`s.
+    public init(URL url: URL) throws {
+        let jsonString = try NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        
+        guard let json = Mapper<SwaggerBuilder>.parseJSONStringIntoDictionary(JSONString: jsonString) else {
+            throw DecodingError()
+        }
+        
+        let resolvedJSON = try json.resolvingReferences(withBaseSpecURL: url)
+        
+        try self.init(JSON: resolvedJSON)
+    }
 }
 
 struct SwaggerBuilder: Builder {

--- a/Tests/SwaggerParserTests/Fixtures/Separated/models/array-item.json
+++ b/Tests/SwaggerParserTests/Fixtures/Separated/models/array-item.json
@@ -1,0 +1,8 @@
+{
+  "required": ["foo"],
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/Separated/models/child.json
+++ b/Tests/SwaggerParserTests/Fixtures/Separated/models/child.json
@@ -1,0 +1,15 @@
+{
+  "allOf": [
+    {
+      "$ref": "parent.json"
+    },
+    {
+      "required": ["reference"],
+      "properties": {
+        "reference": {
+          "$ref": "reference.json"
+        }
+      }
+    }
+  ]
+}

--- a/Tests/SwaggerParserTests/Fixtures/Separated/models/definitions-reference.json
+++ b/Tests/SwaggerParserTests/Fixtures/Separated/models/definitions-reference.json
@@ -1,0 +1,7 @@
+{
+  "properties": {
+    "bar": {
+      "type": "string"
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/Separated/models/parent.json
+++ b/Tests/SwaggerParserTests/Fixtures/Separated/models/parent.json
@@ -1,0 +1,9 @@
+{
+  "discriminator": "type",
+  "required": ["type"],
+  "properties": {
+    "type": {
+      "type": "string"
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/Separated/models/reference.json
+++ b/Tests/SwaggerParserTests/Fixtures/Separated/models/reference.json
@@ -1,0 +1,11 @@
+{
+  "required": ["array-items"],
+  "properties": {
+    "array-items": {
+      "type": "array",
+      "items": {
+        "$ref": "array-item.json"
+      }
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/Separated/test.json
+++ b/Tests/SwaggerParserTests/Fixtures/Separated/test.json
@@ -1,0 +1,32 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test Separated",
+    "description": "",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": ["https"],
+  "produces": ["application/json"],
+  "paths": {
+    "/test": {
+      "get": {
+        "summary": "Test",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "The example response",
+            "schema": {
+              "$ref": "models/child.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "definitions-reference": {
+      "$ref": "models/definitions-reference.json"
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/test_abstract.json
+++ b/Tests/SwaggerParserTests/Fixtures/test_abstract.json
@@ -1,0 +1,54 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test `abstract`",
+    "description": "A test API to validate parsing of the `x-abstract` feature.",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/test-abstract": {
+      "get": {
+        "summary": "Test allOf",
+        "description": "This api is solely defined to test `x-abstract` parsing.",
+        "responses": {
+          "200": {
+            "description": "The example response",
+            "schema": {
+              "$ref": "#/definitions/Abstract"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Abstract": {
+      "x-abstract": true,
+      "properties": {
+        "foo": {
+          "type": "string",
+          "description": "A key/value present on the Abstract object schema"
+        }
+      }
+    },
+    "AbstractAllOf": {
+      "x-abstract": true,
+      "allOf": [{
+        "properties": {
+          "bar": {
+            "type": "string",
+            "description": "A key/value present on the AbstractAllOf allOf schema"
+          }
+        }
+      }]
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/test_all_of.json
+++ b/Tests/SwaggerParserTests/Fixtures/test_all_of.json
@@ -1,0 +1,89 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test allOf",
+    "description": "A test API to validate parsing of the `allOf` feature.",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/test-all-of": {
+      "get": {
+        "summary": "Test allOf",
+        "description": "This api is solely defined to test `allOf` parsing.",
+        "responses": {
+          "200": {
+            "description": "The test-all-of response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TestAllOfBase"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TestAllOfBase": {
+      "required": [
+        "base",
+        "test_type"
+      ],
+      "discriminator": "test_type",
+      "properties": {
+        "base": {
+          "type": "string",
+          "description": "A key/value present on the TestAllOfBase object"
+        },
+        "test_type": {
+          "type": "string",
+          "description": "The type of TestAllOf"
+        }
+      }
+    },
+    "TestAllOfFoo": {
+      "allOf": [{
+          "$ref": "#/definitions/TestAllOfBase"
+        },
+        {
+          "required": [
+            "foo"
+          ],
+          "properties": {
+            "foo": {
+              "type": "string",
+              "description": "A key/value only present on the TestAllOfFoo object"
+            }
+          }
+        }
+      ],
+      "description": "This is an AllOf description."
+    },
+    "TestAllOfBar": {
+      "allOf": [{
+          "$ref": "#/definitions/TestAllOfBase"
+        },
+        {
+          "required": [
+            "bar"
+          ],
+          "properties": {
+            "bar": {
+              "type": "string",
+              "description": "A key/value only present on the TestAllOfBar object"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/test_examples.json
+++ b/Tests/SwaggerParserTests/Fixtures/test_examples.json
@@ -1,0 +1,58 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test allOf",
+    "description": "A test API to validate parsing of the `allOf` feature.",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/test-examples/{exampleId}": {
+      "post": {
+        "summary": "Test allOf",
+        "description": "This api is solely defined to test `example` and `x-example` parsing.",
+        "parameters": [{
+          "name": "exampleId",
+          "in": "path",
+          "description": "The ID of the example",
+          "required": true,
+          "type": "string",
+          "x-example": "E_123"
+        }],
+        "responses": {
+          "201": {
+            "description": "The example response",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "a-string": {
+          "type": "string",
+          "format": "custom",
+          "description": "A key/value present on the TestAllOfBase object",
+          "example": "Example String"
+        },
+        "an-integer": {
+          "type": "integer",
+          "format": "int64",
+          "description": "A test integer",
+          "example": 987
+        }
+      }
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/test_nullable.json
+++ b/Tests/SwaggerParserTests/Fixtures/test_nullable.json
@@ -1,0 +1,29 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "",
+    "description": "",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": ["https"],
+  "produces": ["application/json"],
+  "paths": {},
+  "definitions": {
+    "Test": {
+      "properties": {
+        "foo": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "bar": {
+          "type": "string",
+          "x-nullable": false
+        },
+        "qux": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/test_parameter_references.json
+++ b/Tests/SwaggerParserTests/Fixtures/test_parameter_references.json
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test parameter references",
+    "description": "",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": ["https"],
+  "produces": ["application/json"],
+  "paths": {
+    "/test-parameter-reference": {
+      "post": {
+        "summary": "",
+        "parameters": [{
+          "$ref": "#/parameters/testParam"
+        }],
+        "description": "",
+        "responses": {
+          "201": {
+            "description": "The example response",
+            "schema": {
+              "$ref": "#/definitions/Test"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Test": {
+      "properties": {
+        "foo": {
+          "type": "string",
+          "description": "A key/value present on the Abstract object schema"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "testParam": {
+      "name": "test",
+      "in": "body",
+      "description": "test parameter",
+      "schema": {
+        "$ref": "#/definitions/Test"
+      }
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/test_reference_metadata.json
+++ b/Tests/SwaggerParserTests/Fixtures/test_reference_metadata.json
@@ -1,0 +1,30 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "",
+    "description": "",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": ["https"],
+  "produces": ["application/json"],
+  "paths": {},
+  "definitions": {
+    "Test": {
+      "properties": {
+        "reference": {
+          "$ref": "#/definitions/Reference",
+          "x-nullable": true,
+          "description": "A reference comment."
+        }
+      }
+    },
+    "Reference": {
+      "properties": {
+        "bar": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/Fixtures/uber.json
+++ b/Tests/SwaggerParserTests/Fixtures/uber.json
@@ -1,0 +1,366 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uber API",
+    "description": "Move your app forward with the Uber API",
+    "version": "1.0.0"
+  },
+  "host": "api.uber.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/products": {
+      "get": {
+        "summary": "Product Types",
+        "description": "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",
+        "parameters": [{
+            "name": "latitude",
+            "in": "query",
+            "description": "Latitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "description": "Longitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/price": {
+      "get": {
+        "summary": "Price Estimates",
+        "description": "The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.",
+        "parameters": [{
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_latitude",
+            "in": "query",
+            "description": "Latitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_longitude",
+            "in": "query",
+            "description": "Longitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of price estimates by product",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PriceEstimate"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/time": {
+      "get": {
+        "summary": "Time Estimates",
+        "description": "The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.",
+        "parameters": [{
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "customer_uuid",
+            "in": "query",
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique customer identifier to be used for experience customization."
+          },
+          {
+            "name": "product_id",
+            "in": "query",
+            "type": "string",
+            "description": "Unique identifier representing a specific product for a given latitude & longitude."
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/me": {
+      "get": {
+        "summary": "User Profile",
+        "description": "The User Profile endpoint returns information about the Uber user that has authorized with the application.",
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "Profile information for a user",
+            "schema": {
+              "$ref": "#/definitions/Profile"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/history": {
+      "get": {
+        "summary": "User Activity",
+        "description": "The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.",
+        "parameters": [{
+            "name": "offset",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Offset the list of returned results by this amount. Default is zero."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of items to retrieve. Default is 5, maximum is 100."
+          }
+        ],
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "History information for the given user",
+            "schema": {
+              "$ref": "#/definitions/Activities"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of product."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "capacity": {
+          "type": "string",
+          "description": "Capacity of product. For example, 4 people."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image URL representing the product."
+        }
+      }
+    },
+    "PriceEstimate": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles"
+        },
+        "currency_code": {
+          "type": "string",
+          "description": "[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "estimate": {
+          "type": "string",
+          "description": "Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or \"Metered\" for TAXI."
+        },
+        "low_estimate": {
+          "type": "number",
+          "description": "Lower bound of the estimated price."
+        },
+        "high_estimate": {
+          "type": "number",
+          "description": "Upper bound of the estimated price."
+        },
+        "surge_multiplier": {
+          "type": "number",
+          "description": "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier."
+        }
+      }
+    },
+    "Profile": {
+      "properties": {
+        "first_name": {
+          "type": "string",
+          "description": "First name of the Uber user."
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Last name of the Uber user."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the Uber user"
+        },
+        "picture": {
+          "type": "string",
+          "description": "Image URL of the Uber user."
+        },
+        "promo_code": {
+          "type": "string",
+          "description": "Promo code of the Uber user."
+        }
+      }
+    },
+    "Activity": {
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "description": "Unique identifier for the activity"
+        }
+      }
+    },
+    "Activities": {
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Position in pagination."
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of items to retrieve (100 max)."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of items available."
+        },
+        "history": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Activity"
+          }
+        }
+      }
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/SwaggerParserTests.swift
+++ b/Tests/SwaggerParserTests/SwaggerParserTests.swift
@@ -1,20 +1,366 @@
 import XCTest
 @testable import SwaggerParser
 
-private let uberJSONString = "{\"swagger\":\"2.0\",\"info\":{\"title\":\"Uber API\",\"description\":\"Move your app forward with the Uber API\",\"version\":\"1.0.0\"},\"host\":\"api.uber.com\",\"schemes\":[\"https\"],\"basePath\":\"/v1\",\"produces\":[\"application/json\"],\"paths\":{\"/products\":{\"get\":{\"summary\":\"Product Types\",\"description\":\"The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.\",\"parameters\":[{\"name\":\"latitude\",\"in\":\"query\",\"description\":\"Latitude component of location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"},{\"name\":\"longitude\",\"in\":\"query\",\"description\":\"Longitude component of location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"}],\"tags\":[\"Products\"],\"responses\":{\"200\":{\"description\":\"An array of products\",\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Product\"}}},\"default\":{\"description\":\"Unexpected error\",\"schema\":{\"$ref\":\"#/definitions/Error\"}}}}},\"/estimates/price\":{\"get\":{\"summary\":\"Price Estimates\",\"description\":\"The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.\",\"parameters\":[{\"name\":\"start_latitude\",\"in\":\"query\",\"description\":\"Latitude component of start location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"},{\"name\":\"start_longitude\",\"in\":\"query\",\"description\":\"Longitude component of start location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"},{\"name\":\"end_latitude\",\"in\":\"query\",\"description\":\"Latitude component of end location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"},{\"name\":\"end_longitude\",\"in\":\"query\",\"description\":\"Longitude component of end location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"}],\"tags\":[\"Estimates\"],\"responses\":{\"200\":{\"description\":\"An array of price estimates by product\",\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/PriceEstimate\"}}},\"default\":{\"description\":\"Unexpected error\",\"schema\":{\"$ref\":\"#/definitions/Error\"}}}}},\"/estimates/time\":{\"get\":{\"summary\":\"Time Estimates\",\"description\":\"The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.\",\"parameters\":[{\"name\":\"start_latitude\",\"in\":\"query\",\"description\":\"Latitude component of start location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"},{\"name\":\"start_longitude\",\"in\":\"query\",\"description\":\"Longitude component of start location.\",\"required\":true,\"type\":\"number\",\"format\":\"double\"},{\"name\":\"customer_uuid\",\"in\":\"query\",\"type\":\"string\",\"format\":\"uuid\",\"description\":\"Unique customer identifier to be used for experience customization.\"},{\"name\":\"product_id\",\"in\":\"query\",\"type\":\"string\",\"description\":\"Unique identifier representing a specific product for a given latitude & longitude.\"}],\"tags\":[\"Estimates\"],\"responses\":{\"200\":{\"description\":\"An array of products\",\"schema\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Product\"}}},\"default\":{\"description\":\"Unexpected error\",\"schema\":{\"$ref\":\"#/definitions/Error\"}}}}},\"/me\":{\"get\":{\"summary\":\"User Profile\",\"description\":\"The User Profile endpoint returns information about the Uber user that has authorized with the application.\",\"tags\":[\"User\"],\"responses\":{\"200\":{\"description\":\"Profile information for a user\",\"schema\":{\"$ref\":\"#/definitions/Profile\"}},\"default\":{\"description\":\"Unexpected error\",\"schema\":{\"$ref\":\"#/definitions/Error\"}}}}},\"/history\":{\"get\":{\"summary\":\"User Activity\",\"description\":\"The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.\",\"parameters\":[{\"name\":\"offset\",\"in\":\"query\",\"type\":\"integer\",\"format\":\"int32\",\"description\":\"Offset the list of returned results by this amount. Default is zero.\"},{\"name\":\"limit\",\"in\":\"query\",\"type\":\"integer\",\"format\":\"int32\",\"description\":\"Number of items to retrieve. Default is 5, maximum is 100.\"}],\"tags\":[\"User\"],\"responses\":{\"200\":{\"description\":\"History information for the given user\",\"schema\":{\"$ref\":\"#/definitions/Activities\"}},\"default\":{\"description\":\"Unexpected error\",\"schema\":{\"$ref\":\"#/definitions/Error\"}}}}}},\"definitions\":{\"Product\":{\"properties\":{\"product_id\":{\"type\":\"string\",\"description\":\"Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"},\"description\":{\"type\":\"string\",\"description\":\"Description of product.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Display name of product.\"},\"capacity\":{\"type\":\"string\",\"description\":\"Capacity of product. For example, 4 people.\"},\"image\":{\"type\":\"string\",\"description\":\"Image URL representing the product.\"}}},\"PriceEstimate\":{\"properties\":{\"product_id\":{\"type\":\"string\",\"description\":\"Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles\"},\"currency_code\":{\"type\":\"string\",\"description\":\"[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Display name of product.\"},\"estimate\":{\"type\":\"string\",\"description\":\"Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or \\\"Metered\\\" for TAXI.\"},\"low_estimate\":{\"type\":\"number\",\"description\":\"Lower bound of the estimated price.\"},\"high_estimate\":{\"type\":\"number\",\"description\":\"Upper bound of the estimated price.\"},\"surge_multiplier\":{\"type\":\"number\",\"description\":\"Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.\"}}},\"Profile\":{\"properties\":{\"first_name\":{\"type\":\"string\",\"description\":\"First name of the Uber user.\"},\"last_name\":{\"type\":\"string\",\"description\":\"Last name of the Uber user.\"},\"email\":{\"type\":\"string\",\"description\":\"Email address of the Uber user\"},\"picture\":{\"type\":\"string\",\"description\":\"Image URL of the Uber user.\"},\"promo_code\":{\"type\":\"string\",\"description\":\"Promo code of the Uber user.\"}}},\"Activity\":{\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"Unique identifier for the activity\"}}},\"Activities\":{\"properties\":{\"offset\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"Position in pagination.\"},\"limit\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"Number of items to retrieve (100 max).\"},\"count\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"Total number of items available.\"},\"history\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Activity\"}}}},\"Error\":{\"properties\":{\"code\":{\"type\":\"integer\",\"format\":\"int32\"},\"message\":{\"type\":\"string\"},\"fields\":{\"type\":\"string\"}}}}}"
-
 class SwaggerParserTests: XCTestCase {
-    func testUber() {
-        do {
-            let swagger = try Swagger(JSONString: uberJSONString)
-            print(swagger)
-        } catch {
-            print(error)
+    var testFixtureFolder: URL!
+    
+    override func setUp() {
+        testFixtureFolder = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Fixtures")
+    }
+    
+    func testInitialization() {
+        let url = testFixtureFolder.appendingPathComponent("uber.json")
+        let jsonString = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try! Swagger(JSONString: jsonString)
+        
+        XCTAssertEqual(swagger.host?.absoluteString, "api.uber.com")
+    }
+    
+    func testAllOfSupport() {
+        let url = testFixtureFolder.appendingPathComponent("test_all_of.json")
+        let jsonString = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try! Swagger(JSONString: jsonString)
+        
+        guard
+            let baseDefinition = swagger.definitions.first(where: {$0.name == "TestAllOfBase"}),
+            case .object(let baseSchema) = baseDefinition.structure else {
+                XCTFail("TestAllOfBase is not an object schema."); return
         }
+        
+        SwaggerParserTests.validate(testAllOfBaseSchema: baseSchema)
+        swagger.definitions.validate(testAllOfChild: "TestAllOfFoo", withPropertyNames: ["foo"])
+        swagger.definitions.validate(testAllOfChild: "TestAllOfBar", withPropertyNames: ["bar"])
+        
+        let fooDefinition = swagger.definitions.first(where: {$0.name == "TestAllOfFoo"})!
+        guard case .allOf(let fooSchema) = fooDefinition.structure else {
+            XCTFail("TestAllOfFoo is not an object schema."); return
+        }
+        XCTAssertEqual(fooSchema.metadata.description, "This is an AllOf description.")
+    }
+    
+    func testExamples() {
+        let url = testFixtureFolder.appendingPathComponent("test_examples.json")
+        let jsonString = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try! Swagger(JSONString: jsonString)
+        
+        let definition = swagger.definitions.first(where: {$0.name == "Example"})!
+        guard case .object(let schema) = definition.structure else {
+            XCTFail("Example is not an object schema."); return
+        }
+        
+        guard case .string(let aStringMetadata, let aStringOptionalFormat) = schema.properties["a-string"]! else {
+            XCTFail("Example has no string property 'a-string'."); return
+        }
+        
+        guard
+            let aStringFormat = aStringOptionalFormat,
+            case .other(let aStringFormatValue) = aStringFormat,
+            aStringFormatValue == "custom" else {
+                XCTFail("Example's 'a-string' does not have `custom` format type."); return
+        }
+        
+        XCTAssertEqual(aStringMetadata.example as? String, "Example String")
+        
+        guard case .integer(let anIntegerMetadata, _) = schema.properties["an-integer"]! else {
+            XCTFail("Example has no string property 'an-integer'."); return
+        }
+        
+        XCTAssertEqual(anIntegerMetadata.example as? Int64, 987)
+        
+        let exampleIDOperation = swagger.paths["/test-examples/{exampleId}"]!.operations[.post]!
+        XCTAssertEqual(exampleIDOperation.parameters.count, 1)
+        
+        guard case .a(let exampleIDParameter) = exampleIDOperation.parameters.first! else {
+            XCTFail("Example ID parameter should not be a structure."); return
+        }
+        
+        guard case .other(let exampleIDFixed, _) = exampleIDParameter else {
+            XCTFail("Example ID parameter is not .other."); return
+        }
+        
+        XCTAssertEqual(exampleIDFixed.example as? String, "E_123")
+    }
+    
+    func testAbstract() {
+        let url = testFixtureFolder.appendingPathComponent("test_abstract.json")
+        let jsonString = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try! Swagger(JSONString: jsonString)
+        
+        guard
+            let objectDefinition = swagger.definitions.first(where: {$0.name == "Abstract"}),
+            case .object(let objectSchema) = objectDefinition.structure else {
+                XCTFail("Abstract is not an object schema."); return
+        }
+        XCTAssertTrue(objectSchema.abstract)
+        
+        let allOfDefinition = swagger.definitions.first(where: {$0.name == "AbstractAllOf"})!
+        guard case .allOf(let allOfSchema) = allOfDefinition.structure else {
+            XCTFail("AbstractAllOf is not an allOf schema."); return
+        }
+        XCTAssertTrue(allOfSchema.abstract)
+    }
+    
+    func testNullable() {
+        let url = testFixtureFolder.appendingPathComponent("test_nullable.json")
+        let jsonString = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try! Swagger(JSONString: jsonString)
+        
+        let definition = swagger.definitions.first(where: {$0.name == "Test"})!
+        guard case .object(let object) = definition.structure else {
+            XCTFail("Test is not an object schema."); return
+        }
+        
+        guard
+            let foo = object.properties["foo"],
+            case .string(let fooMetadata, _) = foo else {
+                fatalError("Test has no string property foo.")
+        }
+        XCTAssertTrue(fooMetadata.nullable)
+        
+        guard
+            let bar = object.properties["bar"],
+            case .string(let barMetadata, _) = bar else {
+                fatalError("Test has no string property bar.")
+        }
+        XCTAssertFalse(barMetadata.nullable)
+        
+        guard
+            let qux = object.properties["qux"],
+            case .string(let quxMetadata, _) = qux else {
+                fatalError("Test has no string property qux.")
+        }
+        XCTAssertFalse(quxMetadata.nullable)
+    }
+    
+    func testReferenceMetadata() {
+        let url = testFixtureFolder.appendingPathComponent("test_reference_metadata.json")
+        let jsonString = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try! Swagger(JSONString: jsonString)
+        
+        let definition = swagger.definitions.first(where: {$0.name == "Test"})!
+        guard case .object(let object) = definition.structure else {
+            XCTFail("Test is not an object schema."); return
+        }
+        
+        guard
+            let referenceProperty = object.properties["reference"],
+            case .structure(let referenceStructure) = referenceProperty else {
+                fatalError("Test has no string property foo.")
+        }
+        XCTAssertEqual(referenceStructure.metadata.description, "A reference comment.")
+        XCTAssertTrue(referenceStructure.metadata.nullable)
+    }
+    
+    func testParameterReferences() {
+        let url = testFixtureFolder.appendingPathComponent("test_parameter_references.json")
+        let jsonString = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try! Swagger(JSONString: jsonString)
+        
+        let parameterName = "testParam"
+        let parameter = swagger.parameters.first(where: {$0.name == "testParam"})!.structure
+        let objectName = "Test"
+        let propertyName = "foo"
+        SwaggerParserTests.validate(thatParameter: parameter, named: parameterName, isAnObjectNamed: objectName, withPropertyName: propertyName)
+        
+        guard let eitherParameter = swagger.paths["/test-parameter-reference"]?.operations[.post]?.parameters.first else {
+            XCTFail("POST /test-parameter-reference parameter not found."); return
+        }
+        guard case .b(let parameterStructure) = eitherParameter else {
+            XCTFail("POST /test-parameter-reference parameter not found."); return
+        }
+        XCTAssertEqual(parameterStructure.name, parameterName)
+        SwaggerParserTests.validate(thatParameter: parameterStructure.structure, named: parameterName, isAnObjectNamed: objectName, withPropertyName: propertyName)
+    }
+    
+    func testSeparated() {
+        let url = testFixtureFolder.appendingPathComponent("Separated").appendingPathComponent("test.json")
+        let swagger = try! Swagger(URL: url)
+        XCTAssertEqual(swagger.host?.absoluteString, "api.test.com")
+        
+        XCTAssertEqual(swagger.definitions.count, 5)
+        
+        let parentName = "parent"
+        let parentPropertyNames = ["type"]
+        
+        guard case .object(let parent) = swagger.definitions.first(where: {$0.name == parentName})!.structure else {
+            XCTFail("child is not an object."); return
+        }
+        SwaggerParserTests.validate(thatSchema: parent, named: parentName, hasRequiredProperties: parentPropertyNames)
+        
+        let childName = "child"
+        let childPropertyNames = ["reference"]
+        let childSchema = swagger.definitions.first(where: {$0.name == childName})!.structure
+        
+        SwaggerParserTests.validate(
+            thatChildSchema: childSchema,
+            named: childName,
+            withProperties: childPropertyNames,
+            hasParentNamed: parentName,
+            withProperties: parentPropertyNames)
+        
+        guard
+            let either = swagger.paths["/test"]?.operations[.get]?.responses[200],
+            case .a(let response) = either else {
+                XCTFail("response not found for GET /test 200."); return
+        }
+        guard
+            let responseSchema = response.schema,
+            case .structure(let responseSchemaStructure) = responseSchema else {
+                XCTFail("response schema is not a structure."); return
+        }
+        XCTAssertEqual(responseSchemaStructure.name, childName)
+        
+        let responseChildSchema = responseSchemaStructure.schema
+        
+        SwaggerParserTests.validate(
+            thatChildSchema: responseChildSchema,
+            named: childName,
+            withProperties: childPropertyNames,
+            hasParentNamed: parentName,
+            withProperties: parentPropertyNames)
+        
+        guard case .object(let definitionRef) = swagger.definitions.first(where: {$0.name == "definitions-reference"})!.structure else {
+            XCTFail("`definitions-reference` is not an object."); return
+        }
+        XCTAssertNotNil(definitionRef.properties.first(where: {$0.key == "bar"})?.value)
+        
+        guard case .allOf(let allOf) = responseChildSchema else {
+            XCTFail("Response schema is not an .allOf"); return
+        }
+        XCTAssertEqual(allOf.schemas.count, 2)
+        
+        guard
+            let childAllOfSchema = allOf.schemas.last,
+            case .object(let child) = childAllOfSchema else {
+                XCTFail("Response schema's .allOf's last item is not an .object"); return
+        }
+        
+        guard let referenceProperty = child.properties.first(where: {$0.key == "reference"})?.value else {
+            XCTFail("Response schema's .allOf's last item does not have a 'reference' property."); return
+        }
+        
+        guard
+            case .structure(let referenceStructure) = referenceProperty,
+            referenceStructure.name == "reference",
+            case .object(let reference) = referenceStructure.schema else {
+                XCTFail("Response schema's .allOf's last item's 'reference' property is not a Structure<Schema.object>."); return
+        }
+        
+        guard
+            let arrayProperty = reference.properties.first(where: {$0.key == "array-items"})?.value,
+            case .array(let arraySchema) = arrayProperty,
+            case .one(let arrayItemSchema) = arraySchema.items else {
+                XCTFail("Array property not found on reference."); return
+        }
+        
+        guard
+            case .structure(let arrayStructure) = arrayItemSchema,
+            arrayStructure.name == "array-item",
+            case .object(let arrayItemObjectSchema) = arrayStructure.schema else {
+                XCTFail("`array-items` poprety does not contain an object reference."); return
+        }
+        
+        XCTAssertNotNil(arrayItemObjectSchema.properties.first(where: {$0.key == "foo"})?.value)
+    }
+}
+
+/// MARK: Helper Functions
+
+fileprivate extension SwaggerParserTests {
+    /// Gets the base schema and child schema from a definition that defines an
+    /// `allOf` with one $ref (the base class) and one object schema.
+    class func getBaseAndChildSchemas(withDefinition definition: Structure<Schema>) -> (base: ObjectSchema?, child: ObjectSchema?) {
+        var base: ObjectSchema?
+        var child: ObjectSchema?
+        
+        if case .allOf(let schema) = definition.structure {
+            XCTAssertEqual(schema.schemas.count, 2)
+            
+            schema.schemas.forEach {
+                switch $0 {
+                case .object(let childSchema):
+                    child = childSchema
+                case .structure(let structure):
+                    guard case .object(let baseSchema) = structure.schema else {fatalError()}
+                    base = baseSchema
+                default: fatalError()
+                }
+            }
+        }
+        return (base: base, child: child)
+    }
+}
+
+/// MARK: Validation functions
+
+fileprivate extension SwaggerParserTests {
+    class func validate(testAllOfBaseSchema schema: ObjectSchema) {
+        XCTAssertEqual(schema.discriminator, "test_type")
+        validate(thatSchema: schema, named: "TestAllOfBase", hasRequiredProperties: ["base", "test_type"])
     }
 
+    class func validate(thatSchema schema: ObjectSchema, named name: String, hasRequiredProperties properties: [String]) {
+        XCTAssertEqual(schema.properties.count, properties.count)
+        XCTAssertEqual(schema.required, properties)
+        
+        properties.forEach { property in
+            XCTAssertNotNil(schema.properties.first(where: {$0.key == property}))
+        }
+    }
+    
+    class func validate(thatParameter parameter: Parameter, named parameterName: String, isAnObjectNamed objectName: String, withPropertyName objectPropertyName: String) {
+        guard case .body(_, let schema) = parameter else {
+            XCTFail("\(parameterName) is not a .body."); return
+        }
+        guard case .structure(let structure) = schema else {
+            XCTFail("\(parameterName)'s schema is not a .structure."); return
+        }
+        XCTAssertEqual(structure.name, objectName)
+        
+        guard case .object(let object) = structure.schema else {
+            XCTFail("\(parameterName)'s schema's structure is not an .object."); return
+        }
+        
+        XCTAssertTrue(object.properties.contains(where: {$0.key == objectPropertyName}))
+    }
+    
+    class func validate(thatChildSchema childSchema: Schema, named childName: String, withProperties childProperties: [String], hasParentNamed parentName: String, withProperties parentProperties: [String]) {
+        guard case .allOf(let childAllOf) = childSchema else {
+            XCTFail("\(childName) is not an allOf."); return
+        }
+        XCTAssertEqual(childAllOf.schemas.count, 2)
+        
+        guard
+            let childsParent = childAllOf.schemas.first,
+            case .structure(let childsParentStructure) = childsParent,
+            childsParentStructure.name == parentName,
+            case .object(let childsParentSchema) = childsParentStructure.schema else {
+                XCTFail("\(childName)'s parent is not a Structure<Schema.object>"); return
+        }
+        SwaggerParserTests.validate(thatSchema: childsParentSchema, named: parentName, hasRequiredProperties: parentProperties)
+        
+        guard let discriminator = childsParentSchema.discriminator else {
+            XCTFail("\(parentName) has no discriminator."); return
+        }
+        XCTAssertTrue(parentProperties.contains(discriminator))
+        
+        guard
+            let child = childAllOf.schemas.last,
+            case .object(let childSchema) = child else {
+                XCTFail("child is not a Structure<Schema.object>"); return
+        }
+        SwaggerParserTests.validate(thatSchema: childSchema, named: childName, hasRequiredProperties: childProperties)
+    }
+}
 
-    static var allTests = [
-        ("testUber", testUber),
-    ]
+/// MARK: Swagger Definitions Extension
+
+fileprivate extension Array where Element == Structure<Schema> {
+    func validate(testAllOfChild name: String, withPropertyNames propertyNames: [String]) {
+        let testAllOfChild = self.first(where: {$0.name == name})!
+        let childSchemas = SwaggerParserTests.getBaseAndChildSchemas(withDefinition: testAllOfChild)
+        
+        SwaggerParserTests.validate(testAllOfBaseSchema: childSchemas.base!)
+        SwaggerParserTests.validate(thatSchema: childSchemas.child!, named: name, hasRequiredProperties: propertyNames)
+    }
 }


### PR DESCRIPTION
- `allOf`
- `x-nullable`
- `discriminator`
- `x-abstract`
- `example`/`x-example`
- Separated Swagger spec files (e.g. Base.json, Models/ModelA.json, Models/ModelB.json, etc.)
- Moved test fixture to a file
- Added more unit tests