### PR TITLE
Add abstract support

### DIFF
--- a/Sources/AllOfSchema.swift
+++ b/Sources/AllOfSchema.swift
@@ -3,6 +3,14 @@ import ObjectMapper
 public struct AllOfSchema {
     public let metadata: Metadata
     public let subschemas: [Schema]
+    
+    /// Determines whether or not the schema should be considered abstract code
+    /// generation purposes. This can be used to indicate that a schema is an
+    /// interface rather than a concrete model object.
+    ///
+    /// Corresponds to the boolean value for `x-abstract`. The default value is
+    /// false.
+    public let abstract: Bool
 }
 
 public struct AllOfSchemaBuilder {
@@ -12,14 +20,19 @@ public struct AllOfSchemaBuilder {
     let metadata: MetadataBuilder
     let schemaBuilders: [SchemaBuilder]
     
+    /// See AllOfSchema.abstract
+    let abstract: Bool
+    
     init(map: Map) throws {
         metadata = try MetadataBuilder(map: map)
         
         schemaBuilders = try map.value("allOf")
+        abstract = (try? map.value("x-abstract")) ?? false
     }
     
     func build(_ swagger: SwaggerBuilder) throws -> AllOfSchema {
         let subschemas = try schemaBuilders.map { try $0.build(swagger) }
-        return AllOfSchema(metadata: try self.metadata.build(swagger), subschemas: subschemas)
+        return AllOfSchema(metadata: try self.metadata.build(swagger), subschemas: subschemas,
+                           abstract: self.abstract)
     }
 }

--- a/Sources/AllOfSchema.swift
+++ b/Sources/AllOfSchema.swift
@@ -4,28 +4,25 @@ public struct AllOfSchema {
     public let metadata: Metadata
     public let subschemas: [Schema]
     
-    /// Determines whether or not the schema should be considered abstract code
-    /// generation purposes. This can be used to indicate that a schema is an
-    /// interface rather than a concrete model object.
+    /// Determines whether or not the schema should be considered abstract. This
+    /// can be used to indicate that a schema is an interface rather than a
+    /// concrete model object.
     ///
     /// Corresponds to the boolean value for `x-abstract`. The default value is
     /// false.
     public let abstract: Bool
 }
 
-public struct AllOfSchemaBuilder {
+struct AllOfSchemaBuilder {
     
     typealias Building = AllOfSchema
     
     let metadata: MetadataBuilder
     let schemaBuilders: [SchemaBuilder]
-    
-    /// See AllOfSchema.abstract
     let abstract: Bool
     
     init(map: Map) throws {
         metadata = try MetadataBuilder(map: map)
-        
         schemaBuilders = try map.value("allOf")
         abstract = (try? map.value("x-abstract")) ?? false
     }

--- a/Sources/ObjectSchema.swift
+++ b/Sources/ObjectSchema.swift
@@ -7,6 +7,14 @@ public struct ObjectSchema {
     public let minProperties: Int?
     public let maxProperties: Int?
     public let additionalProperties: Either<Bool, Schema>
+    
+    /// Determines whether or not the schema should be considered abstract code
+    /// generation purposes. This can be used to indicate that a schema is an
+    /// interface rather than a concrete model object.
+    ///
+    /// Corresponds to the boolean value for `x-abstract`. The default value is
+    /// false.
+    public let abstract: Bool
 }
 
 struct ObjectSchemaBuilder: Builder {
@@ -19,6 +27,9 @@ struct ObjectSchemaBuilder: Builder {
     let minProperties: Int?
     let maxProperties: Int?
     let additionalProperties: Either<Bool, SchemaBuilder>
+    
+    /// See ObjectSchema.abstract
+    let abstract: Bool
 
     init(map: Map) throws {
         metadata = try MetadataBuilder(map: map)
@@ -27,6 +38,7 @@ struct ObjectSchemaBuilder: Builder {
         minProperties = try? map.value("minProperties")
         maxProperties = try? map.value("maxProperties")
         additionalProperties = (try? Either(map: map, key: "additionalProperties")) ?? .a(false)
+        abstract = (try? map.value("x-abstract")) ?? false
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> ObjectSchema {
@@ -44,6 +56,7 @@ struct ObjectSchemaBuilder: Builder {
 
         return ObjectSchema(metadata: try self.metadata.build(swagger), required: self.required,
                             properties: properties, minProperties: self.minProperties,
-                            maxProperties: self.maxProperties, additionalProperties: additionalProperties)
+                            maxProperties: self.maxProperties, additionalProperties: additionalProperties,
+                            abstract: self.abstract)
     }
 }

--- a/Sources/ObjectSchema.swift
+++ b/Sources/ObjectSchema.swift
@@ -8,9 +8,9 @@ public struct ObjectSchema {
     public let maxProperties: Int?
     public let additionalProperties: Either<Bool, Schema>
     
-    /// Determines whether or not the schema should be considered abstract code
-    /// generation purposes. This can be used to indicate that a schema is an
-    /// interface rather than a concrete model object.
+    /// Determines whether or not the schema should be considered abstract. This
+    /// can be used to indicate that a schema is an interface rather than a
+    /// concrete model object.
     ///
     /// Corresponds to the boolean value for `x-abstract`. The default value is
     /// false.
@@ -27,8 +27,6 @@ struct ObjectSchemaBuilder: Builder {
     let minProperties: Int?
     let maxProperties: Int?
     let additionalProperties: Either<Bool, SchemaBuilder>
-    
-    /// See ObjectSchema.abstract
     let abstract: Bool
 
     init(map: Map) throws {

--- a/Tests/SwaggerParserTests/Fixtures/test_abstract.json
+++ b/Tests/SwaggerParserTests/Fixtures/test_abstract.json
@@ -1,0 +1,54 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test `abstract`",
+    "description": "A test API to validate parsing of the `x-abstract` feature.",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/test-abstract": {
+      "get": {
+        "summary": "Test allOf",
+        "description": "This api is solely defined to test `x-abstract` parsing.",
+        "responses": {
+          "200": {
+            "description": "The example response",
+            "schema": {
+              "$ref": "#/definitions/Abstract"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Abstract": {
+      "x-abstract": true,
+      "properties": {
+        "foo": {
+          "type": "string",
+          "description": "A key/value present on the Abstract object schema"
+        }
+      }
+    },
+    "AbstractAllOf": {
+      "x-abstract": true,
+      "allOf": [{
+        "properties": {
+          "bar": {
+            "type": "string",
+            "description": "A key/value present on the AbstractAllOf allOf schema"
+          }
+        }
+      }]
+    }
+  }
+}

--- a/Tests/SwaggerParserTests/SwaggerParserTests.swift
+++ b/Tests/SwaggerParserTests/SwaggerParserTests.swift
@@ -32,8 +32,7 @@ class SwaggerParserTests: XCTestCase {
     }
     
     func testAbstract() throws {
-        let url = testFixtureFolder.appendingPathComponent("test_abstract.json")
-        let jsonString = try NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let jsonString = try fixture(named: "test_abstract.json")
         let swagger = try Swagger(JSONString: jsonString)
         
         guard

--- a/Tests/SwaggerParserTests/SwaggerParserTests.swift
+++ b/Tests/SwaggerParserTests/SwaggerParserTests.swift
@@ -30,6 +30,30 @@ class SwaggerParserTests: XCTestCase {
         try validate(that: swagger.definitions, containsTestAllOfChild: "TestAllOfFoo", withPropertyNames: ["foo"])
         try validate(that: swagger.definitions, containsTestAllOfChild: "TestAllOfBar", withPropertyNames: ["bar"])
     }
+    
+    func testAbstract() throws {
+        let url = testFixtureFolder.appendingPathComponent("test_abstract.json")
+        let jsonString = try NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+        let swagger = try Swagger(JSONString: jsonString)
+        
+        guard
+            let objectDefinition = swagger.definitions.first(where: { $0.name == "Abstract" }),
+            case .object(let objectSchema) = objectDefinition.structure else
+        {
+            return XCTFail("Abstract is not an object schema.")
+        }
+        
+        XCTAssertTrue(objectSchema.abstract)
+        
+        guard
+            let allOfDefinition = swagger.definitions.first(where: { $0.name == "AbstractAllOf" }),
+            case .allOf(let allOfSchema) = allOfDefinition.structure else
+        {
+            return XCTFail("AbstractAllOf is not an allOf schema.")
+        }
+        
+        XCTAssertTrue(allOfSchema.abstract)
+    }
 }
 
 /// MARK: Helper Functions


### PR DESCRIPTION
Adds support for `x-abstract` on `ObjectSchema` and `AllOfSchema`.

Allows a developer to declare that a schema is considered abstract. This could be useful for code generation when a developer wants to generate an interface or a protocol instead of a concrete class from a schema definition.

`x-abstract` in combination with `discriminator` allows a developer to declare interesting patterns, like arrays of mixed objects that share an interface and a discrminator to determine (which determines what type of object it should be parsed as).