### PR TITLE
Extract metadata

### DIFF
--- a/Sources/AllOfSchema.swift
+++ b/Sources/AllOfSchema.swift
@@ -26,7 +26,6 @@ struct AllOfSchemaBuilder {
     
     func build(_ swagger: SwaggerBuilder) throws -> AllOfSchema {
         let subschemas = try schemaBuilders.map { try $0.build(swagger) }
-        return AllOfSchema(subschemas: subschemas,
-                           abstract: self.abstract)
+        return AllOfSchema(subschemas: subschemas, abstract: self.abstract)
     }
 }

--- a/Sources/AllOfSchema.swift
+++ b/Sources/AllOfSchema.swift
@@ -1,7 +1,6 @@
 import ObjectMapper
 
 public struct AllOfSchema {
-    public let metadata: Metadata
     public let subschemas: [Schema]
     
     /// Determines whether or not the schema should be considered abstract. This
@@ -16,20 +15,18 @@ public struct AllOfSchema {
 struct AllOfSchemaBuilder {
     
     typealias Building = AllOfSchema
-    
-    let metadata: MetadataBuilder
+
     let schemaBuilders: [SchemaBuilder]
     let abstract: Bool
     
     init(map: Map) throws {
-        metadata = try MetadataBuilder(map: map)
         schemaBuilders = try map.value("allOf")
         abstract = (try? map.value("x-abstract")) ?? false
     }
     
     func build(_ swagger: SwaggerBuilder) throws -> AllOfSchema {
         let subschemas = try schemaBuilders.map { try $0.build(swagger) }
-        return AllOfSchema(metadata: try self.metadata.build(swagger), subschemas: subschemas,
+        return AllOfSchema(subschemas: subschemas,
                            abstract: self.abstract)
     }
 }

--- a/Sources/ArrayItem.swift
+++ b/Sources/ArrayItem.swift
@@ -38,8 +38,6 @@ struct ArrayItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> ArrayItem {
-        return ArrayItem(items: try self.items.build(swagger),
-                         collectionFormat: self.collectionFormat, maxItems: self.maxItems,
-                         minItems: self.minItems, uniqueItems: self.uniqueItems)
+        return ArrayItem(items: try self.items.build(swagger), collectionFormat: self.collectionFormat, maxItems: self.maxItems, minItems: self.minItems, uniqueItems: self.uniqueItems)
     }
 }

--- a/Sources/ArrayItem.swift
+++ b/Sources/ArrayItem.swift
@@ -38,6 +38,7 @@ struct ArrayItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> ArrayItem {
-        return ArrayItem(items: try self.items.build(swagger), collectionFormat: self.collectionFormat, maxItems: self.maxItems, minItems: self.minItems, uniqueItems: self.uniqueItems)
+        return ArrayItem(items: try self.items.build(swagger), collectionFormat: self.collectionFormat, 
+                         maxItems: self.maxItems, minItems: self.minItems, uniqueItems: self.uniqueItems)
     }
 }

--- a/Sources/ArrayItem.swift
+++ b/Sources/ArrayItem.swift
@@ -1,7 +1,6 @@
 import ObjectMapper
 
 public struct ArrayItem {
-    public let metadata: Metadata
 
     /// Describes the type of items in the array.
     public let items: Items
@@ -22,7 +21,6 @@ struct ArrayItemBuilder: Builder {
 
     typealias Building = ArrayItem
 
-    let metadata: MetadataBuilder
     let items: ItemsBuilder
 
     let collectionFormat: CollectionFormat
@@ -31,7 +29,6 @@ struct ArrayItemBuilder: Builder {
     let uniqueItems: Bool
 
     init(map: Map) throws {
-        metadata = try MetadataBuilder(map: map)
         items = try map.value("items")
         collectionFormat = (try? map.value("collectionFormat")) ?? .csv
 
@@ -41,7 +38,7 @@ struct ArrayItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> ArrayItem {
-        return ArrayItem(metadata: try self.metadata.build(swagger), items: try self.items.build(swagger),
+        return ArrayItem(items: try self.items.build(swagger),
                          collectionFormat: self.collectionFormat, maxItems: self.maxItems,
                          minItems: self.minItems, uniqueItems: self.uniqueItems)
     }

--- a/Sources/ArraySchema.swift
+++ b/Sources/ArraySchema.swift
@@ -43,9 +43,8 @@ struct ArraySchemaBuilder: Builder {
             additionalItems = .b(try builder.build(swagger))
         }
 
-        return ArraySchema(items: items, minItems: self.minItems,
-                           maxItems: self.maxItems, additionalItems: additionalItems,
-                           uniqueItems: self.uniqueItems)
+        return ArraySchema(items: items, minItems: self.minItems,maxItems: self.maxItems,
+                           additionalItems: additionalItems, uniqueItems: self.uniqueItems)
     }
 }
 

--- a/Sources/ArraySchema.swift
+++ b/Sources/ArraySchema.swift
@@ -1,7 +1,6 @@
 import ObjectMapper
 
 public struct ArraySchema {
-    public let metadata: Metadata
     public let items: OneOrMany<Schema>
     public let minItems: Int?
     public let maxItems: Int?
@@ -13,7 +12,6 @@ struct ArraySchemaBuilder: Builder {
 
     typealias Building = ArraySchema
 
-    let metadata: MetadataBuilder
     let items: OneOrMany<SchemaBuilder>
     let minItems: Int?
     let maxItems: Int?
@@ -21,7 +19,6 @@ struct ArraySchemaBuilder: Builder {
     let uniqueItems: Bool?
 
     init(map: Map) throws {
-        metadata = try MetadataBuilder(map: map)
         items = try OneOrMany(map: map, key: "items")
         minItems = try? map.value("minItems")
         maxItems = try? map.value("maxItems")
@@ -46,7 +43,7 @@ struct ArraySchemaBuilder: Builder {
             additionalItems = .b(try builder.build(swagger))
         }
 
-        return ArraySchema(metadata: try self.metadata.build(swagger), items: items, minItems: self.minItems,
+        return ArraySchema(items: items, minItems: self.minItems,
                            maxItems: self.maxItems, additionalItems: additionalItems,
                            uniqueItems: self.uniqueItems)
     }

--- a/Sources/IntegerItem.swift
+++ b/Sources/IntegerItem.swift
@@ -32,6 +32,8 @@ struct IntegerItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> IntegerItem {
-        return IntegerItem(format: self.format, maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum, minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum, multipleOf: self.multipleOf)
+        return IntegerItem(format: self.format, maximum: self.maximum,
+                           exclusiveMaximum: self.exclusiveMaximum, minimum: self.minimum, 
+                           exclusiveMinimum: self.exclusiveMinimum, multipleOf: self.multipleOf)
     }
 }

--- a/Sources/IntegerItem.swift
+++ b/Sources/IntegerItem.swift
@@ -1,7 +1,6 @@
 import ObjectMapper
 
 public struct IntegerItem {
-    public let metadata: Metadata
     public let format: IntegerFormat?
 
     public let maximum: Int?
@@ -14,7 +13,6 @@ public struct IntegerItem {
 struct IntegerItemBuilder: Builder {
 
     typealias Building = IntegerItem
-    let metadata: MetadataBuilder
     let format: IntegerFormat?
 
     let maximum: Int?
@@ -24,7 +22,6 @@ struct IntegerItemBuilder: Builder {
     let multipleOf: Int?
 
     init(map: Map) throws {
-        metadata = try MetadataBuilder(map: map)
         format = try? map.value("format")
 
         maximum = try? map.value("maximum")
@@ -35,7 +32,7 @@ struct IntegerItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> IntegerItem {
-        return IntegerItem(metadata: try self.metadata.build(swagger), format: self.format,
+        return IntegerItem(format: self.format,
                            maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum,
                            minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum,
                            multipleOf: self.multipleOf)

--- a/Sources/IntegerItem.swift
+++ b/Sources/IntegerItem.swift
@@ -32,9 +32,6 @@ struct IntegerItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> IntegerItem {
-        return IntegerItem(format: self.format,
-                           maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum,
-                           minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum,
-                           multipleOf: self.multipleOf)
+        return IntegerItem(format: self.format, maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum, minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum, multipleOf: self.multipleOf)
     }
 }

--- a/Sources/Items.swift
+++ b/Sources/Items.swift
@@ -4,8 +4,8 @@ import ObjectMapper
 /// A limited subset of JSON-Schema's items object.
 /// It is used by parameter definitions that are not located in "body".
 public struct Items {
-    let metadata: Metadata
-    let type: ItemsType
+    public let metadata: Metadata
+    public let type: ItemsType
 }
 
 public indirect enum ItemsType {

--- a/Sources/Items.swift
+++ b/Sources/Items.swift
@@ -25,20 +25,7 @@ struct ItemsBuilder: Builder {
 
     init(map: Map) throws {
         metadataBuilder = try MetadataBuilder(map: map)
-        switch metadataBuilder.type {
-        case .string:
-            typeBuilder = .string(builder: try StringItemBuilder(map: map))
-        case .number:
-            typeBuilder = .number(builder: try NumberItemBuilder(map: map))
-        case .integer:
-            typeBuilder = .integer(builder: try IntegerItemBuilder(map: map))
-        case .array:
-            typeBuilder = .array(builder: try ArrayItemBuilder(map: map))
-        case .boolean:
-            typeBuilder = .boolean
-        case .enumeration, .object, .allOf, .pointer, .file, .any:
-            throw DecodingError()
-        }
+        typeBuilder = try ItemsTypeBuilder(map: map)
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> Items {

--- a/Sources/Items.swift
+++ b/Sources/Items.swift
@@ -42,9 +42,8 @@ struct ItemsBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> Items {
-        let metadata = try metadataBuilder.build(swagger)
-        let type = try typeBuilder.build(swagger)
-        return Items(metadata: metadata, type: type)
+        return Items(metadata: try metadataBuilder.build(swagger),
+                     type: try typeBuilder.build(swagger))
     }
 }
 
@@ -59,8 +58,7 @@ indirect enum ItemsTypeBuilder: Builder {
     case boolean
 
     init(map: Map) throws {
-        let dataType = DataType(map: map)
-        switch dataType {
+        switch DataType(map: map) {
         case .string:
             self = .string(builder: try StringItemBuilder(map: map))
         case .number:

--- a/Sources/Items.swift
+++ b/Sources/Items.swift
@@ -59,8 +59,8 @@ indirect enum ItemsTypeBuilder: Builder {
     case boolean
 
     init(map: Map) throws {
-        let metadata = try MetadataBuilder(map: map)
-        switch metadata.type {
+        let dataType = DataType(map: map)
+        switch dataType {
         case .string:
             self = .string(builder: try StringItemBuilder(map: map))
         case .number:

--- a/Sources/Metadata.swift
+++ b/Sources/Metadata.swift
@@ -36,24 +36,7 @@ struct MetadataBuilder: Builder {
     let example: Any?
 
     init(map: Map) throws {
-        if let typeString: String = try? map.value("type"), let mappedType = DataType(rawValue: typeString) {
-            type = mappedType
-        } else if map.JSON["$ref"] != nil {
-            type = .pointer
-        } else if map.JSON["items"] != nil {
-            // Implicit array
-            type = .array
-        } else if map.JSON["properties"] != nil {
-            // Implicit object
-            type = .object
-        } else if map.JSON["enum"] != nil {
-            type = .enumeration
-        } else if map.JSON["allOf"] != nil {
-            type = .allOf
-        } else {
-            type = .any
-        }
-
+        type = DataType(map: map)
         title = try? map.value("title")
         description = try? map.value("description")
         defaultValue = try? map.value("default")
@@ -66,5 +49,28 @@ struct MetadataBuilder: Builder {
         return Metadata(type: self.type, title: self.title, description: self.description,
                         defaultValue: self.defaultValue, enumeratedValues: self.enumeratedValues,
                         nullable: self.nullable, example: self.example)
+    }
+}
+
+extension DataType: ImmutableMappable {
+
+    public init(map: Map) {
+        if let typeString: String = try? map.value("type"), let mappedType = DataType(rawValue: typeString) {
+            self = mappedType
+        } else if map.JSON["$ref"] != nil {
+            self = .pointer
+        } else if map.JSON["items"] != nil {
+            // Implicit array
+            self = .array
+        } else if map.JSON["properties"] != nil {
+            // Implicit object
+            self = .object
+        } else if map.JSON["enum"] != nil {
+            self = .enumeration
+        } else if map.JSON["allOf"] != nil {
+            self = .allOf
+        } else {
+            self = .any
+        }
     }
 }

--- a/Sources/NumberItem.swift
+++ b/Sources/NumberItem.swift
@@ -32,7 +32,8 @@ struct NumberItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> NumberItem {
-        return NumberItem(format: self.format,maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum,
-                          minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum, multipleOf: self.multipleOf)
+        return NumberItem(format: self.format, maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum,
+                          minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum, 
+                          multipleOf: self.multipleOf)
     }
 }

--- a/Sources/NumberItem.swift
+++ b/Sources/NumberItem.swift
@@ -32,9 +32,7 @@ struct NumberItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> NumberItem {
-        return NumberItem(format: self.format,
-                          maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum,
-                          minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum,
-                          multipleOf: self.multipleOf)
+        return NumberItem(format: self.format,maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum,
+                          minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum, multipleOf: self.multipleOf)
     }
 }

--- a/Sources/NumberItem.swift
+++ b/Sources/NumberItem.swift
@@ -1,7 +1,6 @@
 import ObjectMapper
 
 public struct NumberItem {
-    public let metadata: Metadata
     public let format: NumberFormat?
 
     public let maximum: Double?
@@ -14,7 +13,6 @@ public struct NumberItem {
 struct NumberItemBuilder: Builder {
 
     typealias Building = NumberItem
-    let metadata: MetadataBuilder
     let format: NumberFormat?
 
     let maximum: Double?
@@ -24,7 +22,6 @@ struct NumberItemBuilder: Builder {
     let multipleOf: Double?
 
     init(map: Map) throws {
-        metadata = try MetadataBuilder(map: map)
         format = try? map.value("format")
 
         maximum = try? map.value("maximum")
@@ -35,7 +32,7 @@ struct NumberItemBuilder: Builder {
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> NumberItem {
-        return NumberItem(metadata: try self.metadata.build(swagger), format: self.format,
+        return NumberItem(format: self.format,
                           maximum: self.maximum, exclusiveMaximum: self.exclusiveMaximum,
                           minimum: self.minimum, exclusiveMinimum: self.exclusiveMinimum,
                           multipleOf: self.multipleOf)

--- a/Sources/ObjectSchema.swift
+++ b/Sources/ObjectSchema.swift
@@ -1,7 +1,6 @@
 import ObjectMapper
 
 public struct ObjectSchema {
-    public let metadata: Metadata
     public let required: [String]
     public let properties: [String : Schema]
     public let minProperties: Int?
@@ -22,7 +21,6 @@ struct ObjectSchemaBuilder: Builder {
 
     typealias Building = ObjectSchema
 
-    let metadata: MetadataBuilder
     let required: [String]
     let properties: [String : SchemaBuilder]
     let minProperties: Int?
@@ -32,7 +30,6 @@ struct ObjectSchemaBuilder: Builder {
     let abstract: Bool
 
     init(map: Map) throws {
-        metadata = try MetadataBuilder(map: map)
         required = (try? map.value("required")) ?? []
         properties = (try? map.value("properties")) ?? [:]
         minProperties = try? map.value("minProperties")
@@ -55,7 +52,7 @@ struct ObjectSchemaBuilder: Builder {
             additionalProperties = .b(try builder.build(swagger))
         }
 
-        return ObjectSchema(metadata: try self.metadata.build(swagger), required: self.required,
+        return ObjectSchema(required: self.required,
                             properties: properties, minProperties: self.minProperties,
                             maxProperties: self.maxProperties, additionalProperties: additionalProperties,
                             discriminator: self.discriminator, abstract: self.abstract)

--- a/Sources/ObjectSchema.swift
+++ b/Sources/ObjectSchema.swift
@@ -52,8 +52,7 @@ struct ObjectSchemaBuilder: Builder {
             additionalProperties = .b(try builder.build(swagger))
         }
 
-        return ObjectSchema(required: self.required,
-                            properties: properties, minProperties: self.minProperties,
+        return ObjectSchema(required: self.required, properties: properties, minProperties: self.minProperties,
                             maxProperties: self.maxProperties, additionalProperties: additionalProperties,
                             discriminator: self.discriminator, abstract: self.abstract)
     }

--- a/Sources/Schema.swift
+++ b/Sources/Schema.swift
@@ -2,8 +2,8 @@ import ObjectMapper
 
 /// Schemas are used to define the types used in body parameters. They are more expressive than Items.
 public struct Schema {
-    let metadata: Metadata
-    let type: SchemaType
+    public let metadata: Metadata
+    public let type: SchemaType
 }
 
 public enum SchemaType {

--- a/Sources/Schema.swift
+++ b/Sources/Schema.swift
@@ -55,7 +55,7 @@ enum SchemaTypeBuilder: Builder {
     case file
     case any
 
-    public init(map: Map) throws {
+    init(map: Map) throws {
         let dataType = DataType(map: map)
         switch dataType {
         case .pointer:

--- a/Sources/Schema.swift
+++ b/Sources/Schema.swift
@@ -1,41 +1,65 @@
 import ObjectMapper
 
 /// Schemas are used to define the types used in body parameters. They are more expressive than Items.
-public enum Schema {
-    indirect case structure(metadata: Metadata, structure: Structure<Schema>)
+public struct Schema {
+    let metadata: Metadata
+    let type: SchemaType
+}
+
+public enum SchemaType {
+    indirect case structure(Structure<Schema>)
     indirect case object(ObjectSchema)
     indirect case array(ArraySchema)
     indirect case allOf(AllOfSchema)
-    case string(metadata: Metadata, format: StringFormat?)
-    case number(metadata: Metadata, format: NumberFormat?)
-    case integer(metadata: Metadata, format: IntegerFormat?)
-    case enumeration(metadata: Metadata)
-    case boolean(metadata: Metadata)
-    case file(metadata: Metadata)
-    case any(metadata: Metadata)
+    case string(StringFormat?)
+    case number(NumberFormat?)
+    case integer(IntegerFormat?)
+    case enumeration
+    case boolean
+    case file
+    case any
 }
 
-enum SchemaBuilder: Builder {
+struct SchemaBuilder: Builder {
 
     typealias Building = Schema
 
-    indirect case pointer(MetadataBuilder, Pointer<SchemaBuilder>)
+    let metadataBuilder: MetadataBuilder
+    let schemaTypeBuilder: SchemaTypeBuilder
+
+    public init(map: Map) throws {
+        metadataBuilder = try MetadataBuilder(map: map)
+        schemaTypeBuilder = try SchemaTypeBuilder(map: map)
+    }
+
+    func build(_ swagger: SwaggerBuilder) throws -> Schema {
+        let metadata = try metadataBuilder.build(swagger)
+        let schemaType = try schemaTypeBuilder.build(swagger)
+        return Schema(metadata: metadata, type: schemaType)
+    }
+}
+
+enum SchemaTypeBuilder: Builder {
+
+    typealias Building = SchemaType
+
+    indirect case pointer(Pointer<SchemaBuilder>)
     indirect case object(ObjectSchemaBuilder)
     indirect case array(ArraySchemaBuilder)
     indirect case allOf(AllOfSchemaBuilder)
-    case string(metadata: MetadataBuilder, format: StringFormat?)
-    case number(metadata: MetadataBuilder, format: NumberFormat?)
-    case integer(metadata: MetadataBuilder, format: IntegerFormat?)
-    case enumeration(metadata: MetadataBuilder)
-    case boolean(metadata: MetadataBuilder)
-    case file(metadata: MetadataBuilder)
-    case any(metadata: MetadataBuilder)
+    case string(StringFormat?)
+    case number(NumberFormat?)
+    case integer(IntegerFormat?)
+    case enumeration
+    case boolean
+    case file
+    case any
 
     public init(map: Map) throws {
         let metadata = try MetadataBuilder(map: map)
         switch metadata.type {
         case .pointer:
-            self = .pointer(metadata, try Pointer<SchemaBuilder>(map: map))
+            self = .pointer(try Pointer<SchemaBuilder>(map: map))
         case .object:
             self = .object(try ObjectSchemaBuilder(map: map))
         case .array:
@@ -43,47 +67,47 @@ enum SchemaBuilder: Builder {
         case .allOf:
             self = .allOf(try AllOfSchemaBuilder(map: map))
         case .string:
-            self = .string(metadata: metadata, format: try? map.value("format"))
+            self = .string(try? map.value("format"))
         case .number:
-            self = .number(metadata: metadata, format: try? map.value("format"))
+            self = .number(try? map.value("format"))
         case .integer:
-            self = .integer(metadata: metadata, format: try? map.value("format"))
+            self = .integer(try? map.value("format"))
         case .enumeration:
-            self = .enumeration(metadata: metadata)
+            self = .enumeration
         case .boolean:
-            self = .boolean(metadata: metadata)
+            self = .boolean
         case .file:
-            self = .file(metadata: metadata)
+            self = .file
         case .any:
-            self = .any(metadata: metadata)
+            self = .any
         }
     }
 
-    func build(_ swagger: SwaggerBuilder) throws -> Schema {
+    func build(_ swagger: SwaggerBuilder) throws -> SchemaType {
         switch self {
-        case .pointer(let metadataBuilder, let pointer):
+        case .pointer(let pointer):
             let structure = try SchemaBuilder.resolve(swagger, pointer: pointer)
-            return .structure(metadata: try metadataBuilder.build(swagger), structure: structure)
+            return .structure(structure)
         case .object(let builder):
             return .object(try builder.build(swagger))
         case .array(let builder):
             return .array(try builder.build(swagger))
         case .allOf(let builder):
             return .allOf(try builder.build(swagger))
-        case .string(let metadataBuilder, let format):
-            return .string(metadata: try metadataBuilder.build(swagger), format: format)
-        case .number(let metadataBuilder, let format):
-            return .number(metadata: try metadataBuilder.build(swagger), format: format)
-        case .integer(let metadataBuilder, let format):
-            return .integer(metadata: try metadataBuilder.build(swagger), format: format)
-        case .enumeration(let metadataBuilder):
-            return .enumeration(metadata: try metadataBuilder.build(swagger))
-        case .boolean(let metadataBuilder):
-            return .boolean(metadata: try metadataBuilder.build(swagger))
-        case .file(let metadataBuilder):
-            return .file(metadata: try metadataBuilder.build(swagger))
-        case .any(let metadataBuilder):
-            return .any(metadata: try metadataBuilder.build(swagger))
+        case .string(let format):
+            return .string(format)
+        case .number(let format):
+            return .number(format)
+        case .integer(let format):
+            return .integer(format)
+        case .enumeration:
+            return .enumeration
+        case .boolean:
+            return .boolean
+        case .file:
+            return .file
+        case .any:
+            return .any
         }
     }
 }

--- a/Sources/Schema.swift
+++ b/Sources/Schema.swift
@@ -56,8 +56,8 @@ enum SchemaTypeBuilder: Builder {
     case any
 
     public init(map: Map) throws {
-        let metadata = try MetadataBuilder(map: map)
-        switch metadata.type {
+        let dataType = DataType(map: map)
+        switch dataType {
         case .pointer:
             self = .pointer(try Pointer<SchemaBuilder>(map: map))
         case .object:

--- a/Sources/Schema.swift
+++ b/Sources/Schema.swift
@@ -27,15 +27,14 @@ struct SchemaBuilder: Builder {
     let metadataBuilder: MetadataBuilder
     let schemaTypeBuilder: SchemaTypeBuilder
 
-    public init(map: Map) throws {
+    init(map: Map) throws {
         metadataBuilder = try MetadataBuilder(map: map)
         schemaTypeBuilder = try SchemaTypeBuilder(map: map)
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> Schema {
-        let metadata = try metadataBuilder.build(swagger)
-        let schemaType = try schemaTypeBuilder.build(swagger)
-        return Schema(metadata: metadata, type: schemaType)
+        return Schema(metadata: try metadataBuilder.build(swagger), 
+                      type: try schemaTypeBuilder.build(swagger))
     }
 }
 

--- a/Sources/StringItem.swift
+++ b/Sources/StringItem.swift
@@ -1,7 +1,6 @@
 import ObjectMapper
 
 public struct StringItem {
-    public let metadata: Metadata
     public let format: StringFormat?
     public let maxLength: Int?
     public let minLength: Int?
@@ -10,20 +9,17 @@ public struct StringItem {
 struct StringItemBuilder: Builder {
 
     typealias Building = StringItem
-    let metadata: MetadataBuilder
     let format: StringFormat?
     let maxLength: Int?
     let minLength: Int?
 
     init(map: Map) throws {
-        metadata = try MetadataBuilder(map: map)
         format = try? map.value("format")
         maxLength = try? map.value("maxLength")
         minLength = (try? map.value("minLength")) ?? 0
     }
 
     func build(_ swagger: SwaggerBuilder) throws -> StringItem {
-        return StringItem(metadata: try self.metadata.build(swagger),
-                          format: self.format, maxLength: self.maxLength, minLength: self.minLength)
+        return StringItem(format: self.format, maxLength: self.maxLength, minLength: self.minLength)
     }
 }

--- a/Tests/SwaggerParserTests/AbstractTests.swift
+++ b/Tests/SwaggerParserTests/AbstractTests.swift
@@ -8,7 +8,7 @@ class AbstractTests: XCTestCase {
         
         guard
             let objectDefinition = swagger.definitions.first(where: { $0.name == "Abstract" }),
-            case .object(let objectSchema) = objectDefinition.structure else
+            case .object(let objectSchema) = objectDefinition.structure.type else
         {
             return XCTFail("Abstract is not an object schema.")
         }
@@ -17,7 +17,7 @@ class AbstractTests: XCTestCase {
         
         guard
             let allOfDefinition = swagger.definitions.first(where: { $0.name == "AbstractAllOf" }),
-            case .allOf(let allOfSchema) = allOfDefinition.structure else
+            case .allOf(let allOfSchema) = allOfDefinition.structure.type else
         {
             return XCTFail("AbstractAllOf is not an allOf schema.")
         }

--- a/Tests/SwaggerParserTests/AllOfTests.swift
+++ b/Tests/SwaggerParserTests/AllOfTests.swift
@@ -8,7 +8,7 @@ class AllOfTests: XCTestCase {
         
         guard
             let baseDefinition = swagger.definitions.first(where: { $0.name == "TestAllOfBase" }),
-            case .object(let baseSchema) = baseDefinition.structure else
+            case .object(let baseSchema) = baseDefinition.structure.type else
         {
             return XCTFail("TestAllOfBase is not an object schema.")
         }
@@ -19,11 +19,11 @@ class AllOfTests: XCTestCase {
         
         guard
             let fooDefinition = swagger.definitions.first(where: {$0.name == "TestAllOfFoo"}),
-            case .allOf(let fooSchema) = fooDefinition.structure else
+            case .allOf = fooDefinition.structure.type else
         {
             return XCTFail("TestAllOfFoo is not an object schema.")
         }
         
-        XCTAssertEqual(fooSchema.metadata.description, "This is an AllOf description.")
+        XCTAssertEqual(fooDefinition.structure.metadata.description, "This is an AllOf description.")
     }
 }

--- a/Tests/SwaggerParserTests/ChainedReferenceTests.swift
+++ b/Tests/SwaggerParserTests/ChainedReferenceTests.swift
@@ -10,15 +10,15 @@ class ChainedReferenceTests: XCTestCase {
 
         guard
             let foo = swagger.definitions.first(where: { $0.name == "Foo" }),
-            case .object(let fooObject) = foo.structure else
+            case .object(let fooObject) = foo.structure.type else
         {
             return XCTFail("Foo is not an object schema.")
         }
 
         guard
             let barProperty = fooObject.properties.values.first,
-            case .structure(_, let barStructureSchema) = barProperty,
-            case .object = barStructureSchema.structure else
+            case .structure(let barStructureSchema) = barProperty.type,
+            case .object = barStructureSchema.structure.type else
         {
             return XCTFail("Bar property wasn't resolved correctly")
         }
@@ -29,15 +29,15 @@ class ChainedReferenceTests: XCTestCase {
 
         guard
             let bar = swagger.definitions.first(where: { $0.name == "Bar" }),
-            case .object(let barObject) = bar.structure else
+            case .object(let barObject) = bar.structure.type else
         {
             return XCTFail("Bar is not an object schema.")
         }
 
         guard
             let bazProperty = barObject.properties.values.first,
-            case .structure(_, let bazStructureSchema) = bazProperty,
-            case .object = bazStructureSchema.structure else
+            case .structure(let bazStructureSchema) = bazProperty.type,
+            case .object = bazStructureSchema.structure.type else
         {
             return XCTFail("Baz property wasn't resolved correctly")
         }
@@ -48,14 +48,14 @@ class ChainedReferenceTests: XCTestCase {
 
         guard
             let baz = swagger.definitions.first(where: { $0.name == "Baz" }),
-            case .object(let bazObject) = baz.structure else
+            case .object(let bazObject) = baz.structure.type else
         {
             return XCTFail("Bar is not an object schema.")
         }
 
         guard
             let quxProperty = bazObject.properties.values.first,
-            case .string = quxProperty else
+            case .string = quxProperty.type else
         {
             return XCTFail("Qux property wasn't resolved correctly")
         }

--- a/Tests/SwaggerParserTests/CrossReferenceTests.swift
+++ b/Tests/SwaggerParserTests/CrossReferenceTests.swift
@@ -8,7 +8,7 @@ class CrossReferenceTests: XCTestCase {
 
         guard
             let definition = swagger.definitions.first(where: { $0.name == "Foo" }),
-            case .structure = definition.structure else
+            case .structure = definition.structure.type else
         {
             return XCTFail("Foo is not a structure schema.")
         }

--- a/Tests/SwaggerParserTests/ExampleTests.swift
+++ b/Tests/SwaggerParserTests/ExampleTests.swift
@@ -8,14 +8,14 @@ class ExampleTests: XCTestCase {
         
         guard
             let definition = swagger.definitions.first(where: { $0.name == "Example" }),
-            case .object(let schema) = definition.structure else
+            case .object(let schema) = definition.structure.type else
         {
             return XCTFail("Example is not an object schema.")
         }
         
         guard
             let aStringProperty = schema.properties["a-string"],
-            case .string(let aStringMetadata, let aStringOptionalFormat) = aStringProperty else
+            case .string(let aStringOptionalFormat) = aStringProperty.type else
         {
             return XCTFail("Example has no string property 'a-string'.")
         }
@@ -28,16 +28,16 @@ class ExampleTests: XCTestCase {
             return XCTFail("Example's 'a-string' does not have `custom` format type.")
         }
         
-        XCTAssertEqual(aStringMetadata.example as? String, "Example String")
+        XCTAssertEqual(aStringProperty.metadata.example as? String, "Example String")
         
         guard
             let anIntegerProperty = schema.properties["an-integer"],
-            case .integer(let anIntegerMetadata, _) = anIntegerProperty else
+            case .integer = anIntegerProperty.type else
         {
             return XCTFail("Example has no string property 'an-integer'.")
         }
         
-        XCTAssertEqual(anIntegerMetadata.example as? Int64, 987)
+        XCTAssertEqual(anIntegerProperty.metadata.example as? Int64, 987)
         
         guard
             let exampleIDPath = swagger.paths["/test-examples/{exampleId}"],

--- a/Tests/SwaggerParserTests/NullableTests.swift
+++ b/Tests/SwaggerParserTests/NullableTests.swift
@@ -8,36 +8,33 @@ class NullableTests: XCTestCase {
         
         guard
             let definition = swagger.definitions.first(where: { $0.name == "Test" }),
-            case .object(let object) = definition.structure else
+            case .object(let object) = definition.structure.type else
         {
             return XCTFail("Test is not an object schema.")
         }
         
         guard
-            let foo = object.properties["foo"],
-            case .string(let fooMetadata, _) = foo else
+            let foo = object.properties["foo"] else
         {
             return XCTFail("Test has no string property foo.")
         }
         
-        XCTAssertTrue(fooMetadata.nullable)
+        XCTAssertTrue(foo.metadata.nullable)
         
         guard
-            let bar = object.properties["bar"],
-            case .string(let barMetadata, _) = bar else
+            let bar = object.properties["bar"] else
         {
             return XCTFail("Test has no string property bar.")
         }
         
-        XCTAssertFalse(barMetadata.nullable)
+        XCTAssertFalse(bar.metadata.nullable)
         
         guard
-            let qux = object.properties["qux"],
-            case .string(let quxMetadata, _) = qux else
+            let qux = object.properties["qux"] else
         {
             return XCTFail("Test has no string property qux.")
         }
         
-        XCTAssertFalse(quxMetadata.nullable)
+        XCTAssertFalse(qux.metadata.nullable)
     }
 }

--- a/Tests/SwaggerParserTests/StructureSchemaTests.swift
+++ b/Tests/SwaggerParserTests/StructureSchemaTests.swift
@@ -8,28 +8,28 @@ class StructureSchemaTests: XCTestCase {
         
         guard
             let fooDefinition = swagger.definitions.first(where: { $0.name == "Foo" }),
-            case .object(let foo) = fooDefinition.structure else
+            case .object(let foo) = fooDefinition.structure.type else
         {
             return XCTFail("Foo is not an object schema.")
         }
         
         guard
             let barProperty = foo.properties["bar"],
-            case .structure(let metadata, let barReference) = barProperty,
-            case .object(let bar) = barReference.structure else
+            case .structure(let barReference) = barProperty.type,
+            case .object(let bar) = barReference.structure.type else
         {
             return XCTFail("Bar property is not a reference to an object schema.")
         }
         
         guard
             let bazProperty = bar.properties["baz"],
-            case .string = bazProperty else
+            case .string = bazProperty.type else
         {
             return XCTFail("Baz property is not a string.")
         }
         
-        XCTAssertEqual(metadata.description, "A nullable reference to Bar.")
-        XCTAssertTrue(metadata.nullable)
+        XCTAssertEqual(barProperty.metadata.description, "A nullable reference to Bar.")
+        XCTAssertTrue(barProperty.metadata.nullable)
     }
 }
 

--- a/Tests/SwaggerParserTests/TestHelpers.swift
+++ b/Tests/SwaggerParserTests/TestHelpers.swift
@@ -14,7 +14,7 @@ func fixture(named fileName: String) throws -> String {
 enum GetBaseAndChildSchemasError: Error {
     case missingBase
     case missingChild
-    case badSubschemaType(Schema)
+    case badSubschemaType(SchemaType)
     case notAllOf
     case incorrectSubschemaCount
 }
@@ -22,7 +22,7 @@ enum GetBaseAndChildSchemasError: Error {
 /// Gets the base schema and child schema from a definition that defines an
 /// `allOf` with one $ref (the base class) and one object schema.
 func getBaseAndChildSchemas(withDefinition definition: Structure<Schema>) throws -> (base: ObjectSchema, child: ObjectSchema) {
-    guard case .allOf(let allOfSchema) = definition.structure else {
+    guard case .allOf(let allOfSchema) = definition.structure.type else {
         throw GetBaseAndChildSchemasError.notAllOf
     }
     
@@ -33,12 +33,12 @@ func getBaseAndChildSchemas(withDefinition definition: Structure<Schema>) throws
     var base: ObjectSchema!
     var child: ObjectSchema!
     
-    try allOfSchema.subschemas.forEach { subschema in
+    try allOfSchema.subschemas.map { $0.type }.forEach { subschema in
         switch subschema {
         case .object(let childSchema):
             child = childSchema
-        case .structure(_, let structure):
-            guard case .object(let baseSchema) = structure.structure else {
+        case .structure(let structure):
+            guard case .object(let baseSchema) = structure.structure.type else {
                 throw GetBaseAndChildSchemasError.badSubschemaType(subschema)
             }
             
@@ -78,13 +78,13 @@ func validate(that parameter: Parameter, named parameterName: String, isAnObject
         return XCTFail("\(parameterName) is not a .body.")
     }
     
-    guard case .structure(_, let structure) = schema else {
+    guard case .structure(let structure) = schema.type else {
         return XCTFail("\(parameterName)'s schema is not a .structure.")
     }
     
     XCTAssertEqual(structure.name, objectName)
     
-    guard case .object(let object) = structure.structure else {
+    guard case .object(let object) = structure.structure.type else {
         return XCTFail("\(parameterName)'s schema's structure is not an .object.")
     }
     
@@ -92,7 +92,7 @@ func validate(that parameter: Parameter, named parameterName: String, isAnObject
 }
 
 func validate(that childSchema: Schema, named childName: String, withProperties childProperties: [String], hasParentNamed parentName: String, withProperties parentProperties: [String]) {
-    guard case .allOf(let childAllOf) = childSchema else {
+    guard case .allOf(let childAllOf) = childSchema.type else {
         return XCTFail("\(childName) is not an allOf.")
     }
     
@@ -100,9 +100,9 @@ func validate(that childSchema: Schema, named childName: String, withProperties 
     
     guard
         let childsParent = childAllOf.subschemas.first,
-        case .structure(_, let childsParentStructure) = childsParent,
+        case .structure(let childsParentStructure) = childsParent.type,
         childsParentStructure.name == parentName,
-        case .object(let childsParentSchema) = childsParentStructure.structure else
+        case .object(let childsParentSchema) = childsParentStructure.structure.type else
     {
         return XCTFail("\(childName)'s parent is not a Structure<Schema.object>")
     }
@@ -115,7 +115,7 @@ func validate(that childSchema: Schema, named childName: String, withProperties 
     
     XCTAssertTrue(parentProperties.contains(discriminator))
     
-    guard let child = childAllOf.subschemas.last, case .object(let childSchema) = child else {
+    guard let child = childAllOf.subschemas.last, case .object(let childSchema) = child.type else {
         return XCTFail("child is not a Structure<Schema.object>")
     }
     


### PR DESCRIPTION
This extracts the metadata property out of each Schema and Items case. This:

- makes accessing the metadata property easier without switches or casing of enums (especially useful for templates or anything that needs easy access)
- cleans up a lot of reduntant code

The enums are now moved into their own property, and just contain data relevant to them. It does change the public api slightly by making the schema enum be `schema.type` instead of `schema`

What do you think?